### PR TITLE
Add the abstract and restrict use cases

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -6,10 +6,11 @@ Note: for Test Cases still in development, see the `proposed` branch.
 
 * [subclass](subclass) -- choice menu is missing base class and subclass of subclass
 * [abstract](abstract) -- unclear due to [subclass](subclass)
+* [restrict](restrict) -- not working due to lack of support for subclass of subclass
 
 ## Closed Test Cases
 
-* token -- verified @RayPlante, 8 Dec 2016
+* [token](token) -- verified @RayPlante, 8 Dec 2016
 
 
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,7 +4,8 @@ Note: for Test Cases still in development, see the `proposed` branch.
 
 ## Open Test Cases
 
-* subclass -- choice menu is missing base class and subclass of subclass
+* [subclass](subclass) -- choice menu is missing base class and subclass of subclass
+* [abstract](abstract) -- unclear due to [subclass](subclass)
 
 ## Closed Test Cases
 

--- a/abstract/README.md
+++ b/abstract/README.md
@@ -28,7 +28,7 @@ ones.  See [restrict](../restrict) for an example.
 ## Run this Test
 
 1. Load [`labs-abseq.xsd`](labs-abseq.xsd) in as a template.
-2. Open up the new document form and inspect the form; ensure all
+2. Open up the new document form and inspect the form; ensure all non-abstract
    classes appear in the menu and the form updates properly for each
    type when chosen.
 3. Complete the form and inspect the output XML document (click on

--- a/abstract/README.md
+++ b/abstract/README.md
@@ -1,0 +1,38 @@
+# Support for `xsi:type` and XML Subclasses
+
+This Test Case is just like that demonstrated in
+[subclass](../subclass) except that the base class is declared
+abstract.  It not only prevents an element from being instantiated
+with the type, but it also forces the use of `xsi:type`.  
+
+The [`labs.xsd`](labs.xsd) schema defines a base complex type called
+`Equipment` containing two child elements, _and which is declared
+abstract_.  The `ElectronMicroscope` extends `Equipment`, adding a
+third child element, and the `TunnellingElectronMicrocope` extends
+`ElectronMicroscope` to further add a fourth child element.
+
+When MDCS creates a form for this schema as a template, at the point
+where a piece of equipment can be described, it should present a
+drop-down menu that offers only `ElectronMicroscope`, and
+`TunnellingElectronMicrocope` as choices; `Equipment` should not be
+offered as option (since it is abstract).  The form for the content
+elements should update depending on the choice made.
+
+The output XML data should make proper use of the `xsi:type` attribute
+to identify the subclass of `Equipment` was chosen.
+
+The abstract feature is helpful when one wants to provide a subclass
+that both restricts the inherited content but also extends it with new
+ones.  See [restrict](../restrict) for an example.
+
+## Run this Test
+
+1. Load [`labs-abseq.xsd`](labs-abseq.xsd) in as a template.
+2. Open up the new document form and inspect the form; ensure all
+   classes appear in the menu and the form updates properly for each
+   type when chosen.
+3. Complete the form and inspect the output XML document (click on
+   "Download XML"); ensure `xsi:type` is used.
+4. Load [`microlab.xml`](microlab.xml) as a new records; inspect 
+   the form and the downloaded output XML. 
+

--- a/abstract/STATUS.md
+++ b/abstract/STATUS.md
@@ -1,0 +1,16 @@
+# Status of this Test Case
+
+**Test Case Name:** | subclass
+**Current Status:** | :bangbang: open
+
+## Versions and Flavors
+
+### MDCS : master branch, 8 Dec 2016
+
+*  Although the abstract base class is not included, given the current
+   behavior of [subclass](../subclass), it's likely that this test
+   case's behavior is correct for the wrong reasons.  That is, it is
+   not clear whether the application recognizes the `abstract`
+   attribute. 
+
+*  Subclass of subclass not included.

--- a/abstract/labs-abseq.xsd
+++ b/abstract/labs-abseq.xsd
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="urn:labs-abseq"
+           xmlns:ex="urn:labs-abseq"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified">
+  <xs:element name="Lab" type="ex:LabSetup"/>
+
+  <xs:complexType name="LabSetup">
+    <xs:sequence>
+      <xs:element name="equipment" type="ex:Equipment" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="Equipment" abstract="true">
+    <xs:sequence>
+      <xs:element name="vendor" type="xs:token"/>
+      <xs:element name="model" type="xs:token"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="ElectronMicroscope">
+    <xs:complexContent>
+      <xs:extension base="ex:Equipment">
+        <xs:sequence>
+          <xs:element name="magnification" type="xs:decimal"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="TunnellingElectronMicroscope">
+    <xs:complexContent>
+      <xs:extension base="ex:ElectronMicroscope">
+        <xs:sequence>
+          <xs:element name="voltage" type="xs:decimal"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="VacuumPump">
+    <xs:complexContent>
+      <xs:extension base="ex:Equipment">
+        <xs:sequence>
+          <xs:element name="pressure" type="xs:decimal"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+</xs:schema>

--- a/abstract/microlab.xml
+++ b/abstract/microlab.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Lab xmlns="urn:labs-abseq"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:labs-abseq labs-abseq.xsd">
+  
+  <equipment xsi:type="VacuumPump">
+    <vendor>Acme</vendor>
+    <model>Big Void</model>
+    <pressure> 0.001 </pressure>
+  </equipment>
+
+  <equipment xsi:type="ElectronMicroscope">
+    <vendor>Micro Heaven</vendor>
+    <model> x1440 </model>
+    <magnification> 1000.0 </magnification>
+  </equipment>
+</Lab>

--- a/restrict/README.md
+++ b/restrict/README.md
@@ -1,0 +1,45 @@
+# Support for `xsi:type` and XML Subclasses
+
+This Test Case demonstrates the case when you wants to subclass by
+restriction and extension simultaneously.  That is, you might want to
+fix the values of some content as well as add some additional
+content.  Since XML Schema does not allow one to do both of these in
+the same subclass, the solution is to first subclass by restriction
+and then again by extension.  You probably don't want to make the
+intermediate restricted class available, so you would make that
+abstract.  
+
+This Test Case is much like that demonstrated in
+[subclass](../subclass).  In this example, an abstract class is
+inserted in the inheritance tree to `ElectronMicroscope` that
+restricts the type attribute by setting a default value.  
+
+The [`labs.xsd`](labs.xsd) schema defines a base complex type called
+`Equipment` containing two child elements.  The `ElectronMicroscope`
+extends `Equipment`, adding a third child element, and the
+`TunnellingElectronMicrocope` extends `ElectronMicroscope` to further
+add a fourth child element.
+
+When MDCS creates a form for this schema as a template, at the point
+where a piece of equipment can be described, it should present a
+drop-down menu that offers `Equipment`, `ElectronMicroscope`, 
+`TunnellingElectronMicrocope`, and `VacuumPump` as choices.  It should
+not offer `_ElectronicMicroscope` (the abstract intermediate subclass)
+as a choice.  The form for the content elements should update
+depending on the choice made. 
+
+The output XML data should make proper use of the `xsi:type` attribute
+to identify the subclass of `Equipment` was chosen.
+
+## Run this Test
+
+1. Load [`labs-restr.xsd`](labs-restr.xsd) in as a template.
+2. Open up the new document form and inspect the form; ensure all
+   non-abstract classes appear in the menu and the form updates
+   properly for each type when chosen.
+3. Complete the form and inspect the output XML document (click on
+   "Download XML"); ensure `xsi:type` is used.
+4. Load [`genericlab.xml`](genericlab.xml) and
+   [`microlab.xml`](microlab.xml) as a new records; inspect 
+   the form and the downloaded output XML. 
+

--- a/restrict/STATUS.md
+++ b/restrict/STATUS.md
@@ -1,0 +1,22 @@
+# Status of this Test Case
+
+**Test Case Name:** | subclass
+**Current Status:** | :bangbang: open
+
+## Versions and Flavors
+
+### MDCS : master branch, 8 Dec 2016
+
+*  Only VacuumPump is offered as an option.  
+
+*  The behavior of [subclass](../subclass) and 
+   [abstract](../abstract) offer clues as to why only VacuumPump is
+   offered as a choice:
+   * [subclass](../subclass) shows that base classes are not being
+     offered
+   * [subclass](../subclass) also shows that subclasses of subclasses
+     are not offered
+   * while [abstract](../abstract) is ambiguous on its own, this test
+     suggests that abstract is being honored, since it is not being
+     offered.
+

--- a/restrict/genericlab.xml
+++ b/restrict/genericlab.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Lab xmlns="urn:labs-restr" 
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:labs-restr labs-restr.xsd">
+  <equipment type="magnet">
+    <vendor>Acme</vendor>
+    <model>Big Horseshoe Magnet</model>
+  </equipment>
+</Lab>

--- a/restrict/labs-restr.xsd
+++ b/restrict/labs-restr.xsd
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="urn:labs-restr"
+           xmlns:ex="urn:labs-restr"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified">
+  <xs:element name="Lab" type="ex:LabSetup"/>
+
+  <xs:complexType name="LabSetup">
+    <xs:sequence>
+      <xs:element name="equipment" type="ex:Equipment" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="Equipment">
+    <xs:sequence>
+      <xs:element name="vendor" type="xs:token"/>
+      <xs:element name="model" type="xs:token"/>
+    </xs:sequence>
+    <xs:attribute name="type" type="xs:token"/>
+  </xs:complexType>
+
+  <xs:complexType name="_ElectronMicroscope" abstract="true">
+    <xs:complexContent>
+      <xs:restriction base="ex:Equipment">
+        <xs:sequence>
+          <xs:element name="vendor" type="xs:token"/>
+          <xs:element name="model" type="xs:token"/>
+        </xs:sequence>
+        <xs:attribute name="type" type="xs:token" default="electron microscope"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="ElectronMicroscope">
+    <xs:complexContent>
+      <xs:extension base="ex:_ElectronMicroscope">
+        <xs:sequence>
+          <xs:element name="magnification" type="xs:decimal"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="TunnellingElectronMicroscope">
+    <xs:complexContent>
+      <xs:extension base="ex:ElectronMicroscope">
+        <xs:sequence>
+          <xs:element name="voltage" type="xs:decimal"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="VacuumPump">
+    <xs:complexContent>
+      <xs:extension base="ex:Equipment">
+        <xs:sequence>
+          <xs:element name="pressure" type="xs:decimal"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+</xs:schema>

--- a/restrict/microlab.xml
+++ b/restrict/microlab.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Lab xmlns="urn:labs-restr"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:labs-restr labs-restr.xsd">
+  
+  <equipment type="magnet">
+    <vendor>Acme</vendor>
+    <model>Big Horseshoe Magnet</model>
+  </equipment>
+
+  <equipment xsi:type="ElectronMicroscope" type="tem">
+    <vendor>Micro Heaven</vendor>
+    <model> x1440 </model>
+    <magnification> 1000.0 </magnification>
+  </equipment>
+</Lab>


### PR DESCRIPTION
**abstract** tests the use of the `abstract` attribute on a `complexType`.  **restrict** tests a pattern for subclassing a `complexType` by restriction (and then extension).
