### PR TITLE
ExtensionSchema part 2

### DIFF
--- a/extensionSchema/STATUS.md
+++ b/extensionSchema/STATUS.md
@@ -1,6 +1,6 @@
 # Status of this Test Case
 
-**Test Case Name:**  subclass
+**Test Case Name:**  unqualified
 
 **Current Status:**  :bangbang: open
 
@@ -10,26 +10,6 @@
 
 ### MDCS : master branch, 8 Dec 2016
 
-  * import statement:
-    *  schema uploader claims that schemaLocation is required but
-       this is not strictly true.  It's not clear what the proper
-       value should be in the context of the curator.
-    *  when including a schemaLocation element, it fails to validate
-       the schema, due to:
+*  this appears to behave identically to the
+   [extensionSchema](../extensionSchema) test case
 
-         > Not a valid XML schema.
-         > complex type ElectronMicroscope, attribute base: The QName value {urn:experiments}Equipment does not resolve to a(n) simple type definition., line 14
-
-    *  When you are alerted about an import statement, the GUI says:
-
-       > Please check that the resource is accessible (not on your local file system, or on a server down).
-
-       I don't understand what this means; some better wording is
-       probably in order.
-
-    *  import works when schemaLocation is a file: URL on the server.
-  *  if a global element does not exist, it uses xsi:type to for an
-     OTF root element based on a global type.
-  *  Regardless of the existence of a global element, it does not
-     render type model correctly.  It displays simply the global
-     element name and a text field.  

--- a/extensionSchema/extlab.xml
+++ b/extensionSchema/extlab.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Lab xmlns="urn:experiments"
+     xmlns:mi="urn:microscopy"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:experiments experiments.xsd
+                         urn:microscopy microscopy.xsd">
+  <equipment>
+    <vendor>Acme</vendor>
+    <model>Big Horseshoe Magnet</model>
+  </equipment>
+
+  <equipment xsi:type="mi:ElectronMicroscope">
+    <vendor>Micro Heaven</vendor>
+    <model> x1440 </model>
+    <mi:magnification> 1000.0 </mi:magnification>
+  </equipment>
+</Lab>

--- a/extensionSchema/microscopy.xsd
+++ b/extensionSchema/microscopy.xsd
@@ -13,7 +13,9 @@
   <xs:import namespace="urn:experiments"/>
   -->
 
+<!--
   <xs:element name="MicroLab" type="ex:LabSetup"/>
+  -->
   
 
   <xs:complexType name="ElectronMicroscope">

--- a/unqualified/README.md
+++ b/unqualified/README.md
@@ -1,0 +1,51 @@
+# Support for `elementFormDefault="unqualified"`
+
+This is a variation on the [extensionSchema](../extensionSchema) test
+case where the schema's `elementFormDefault` attribute is set to
+`unqualified`.  This says that non-global elements do not require
+namespace qualification.  (Technically, it means that non-global
+elements belong to the no-name namespace.)  In the pattern shown here,
+only the root element and `xsi:type` values require namespace
+qualifiers.  
+
+This is setting is useful when mixing types from different namespaces
+are mixed together.  Instance authors do not have to be cognizant of
+which elements in an extended type come from which schema.  XML Paths
+are simpler as well for the same reason.  Instance documents become
+less error-prone.  
+
+## Test Details
+
+The [`experiments.xsd`](experiments.xsd) file defines the core schema
+with a root element, `LabSetup`, that takes a list of equipment
+descriptions via the `equipment` element.  It defines a default
+complex `Equipment` type that can capture some generic metadata
+(`vendor` and `model`).  The [`microscopy.xsd`](microscopy.xsd) file
+is the extension schema; it defines an extension of `Equipment` called
+`ElectronMicroscope`.  This latter type adds an additional element to
+the content (`magnification`).
+
+When loaded into MDCS and the curation form is produced, it should
+offer a drop-down menu where a piece of equipment can be
+described. The menu should offer the generic `Equipment` base class and
+the `ElectronMicroscope` as options.
+
+To make exported documents more human readable, it is recommended that
+the default namespace be set to the no-name namespace
+(i.e. `xmlns=""`), and the root element is qualified with a defined
+namespace prefix.  
+
+## Run this Test
+
+1. Load [`experiments.xsd`](experiments.xsd) in as a template.
+2. Load [`microscopy.xsd`](microscopy.xsd) in as a template.  _Not
+   sure about this_
+2. Open up the new document form and inspect the form; ensure all
+   classes appear in the menu and the form updates properly for each
+   type when chosen.
+3. Complete the form and inspect the output XML document (click on
+   "Download XML"); ensure `xsi:type` is used.
+4. Load [`genericlab.xml`](genericlab.xml) and
+   [`microlab.xml`](microlab.xml) as a new records; inspect 
+   the form and the downloaded output XML. 
+

--- a/unqualified/STATUS.md
+++ b/unqualified/STATUS.md
@@ -1,0 +1,35 @@
+# Status of this Test Case
+
+**Test Case Name:**  unqualified
+
+**Current Status:**  :bangbang: open
+
+**Note:**  _It is still not clear the best way to test this test case._
+
+## Versions and Flavors
+
+### MDCS : master branch, 8 Dec 2016
+
+  * import statement:
+    *  schema uploader claims that schemaLocation is required but
+       this is not strictly true.  It's not clear what the proper
+       value should be in the context of the curator.
+    *  when including a schemaLocation element, it fails to validate
+       the schema, due to:
+
+         > Not a valid XML schema.
+         > complex type ElectronMicroscope, attribute base: The QName value {urn:experiments}Equipment does not resolve to a(n) simple type definition., line 14
+
+    *  When you are alerted about an import statement, the GUI says:
+
+       > Please check that the resource is accessible (not on your local file system, or on a server down).
+
+       I don't understand what this means; some better wording is
+       probably in order.
+
+    *  import works when schemaLocation is a file: URL on the server.
+  *  if a global element does not exist, it uses xsi:type to for an
+     OTF root element based on a global type.
+  *  Regardless of the existence of a global element, it does not
+     render type model correctly.  It displays simply the global
+     element name and a text field.  

--- a/unqualified/experiments.xsd
+++ b/unqualified/experiments.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="urn:experiments-uq"
+           xmlns:ex="urn:experiments-uq"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="unqualified">
+  <xs:element name="Lab" type="ex:LabSetup"/>
+
+  <xs:complexType name="LabSetup">
+    <xs:sequence>
+      <xs:element name="equipment" type="ex:Equipment" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="Equipment">
+    <xs:sequence>
+      <xs:element name="vendor" type="xs:token"/>
+      <xs:element name="model" type="xs:token"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  
+</xs:schema>

--- a/unqualified/extlab.xml
+++ b/unqualified/extlab.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ex:Lab xmlns:ex="urn:experiments-uq" xmlns:mi="urn:microscopy-uq" xmlns=""
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:experiments-uq experiments.xsd
+                         urn:microscopy-uq microscopy.xsd">
+  <equipment>
+    <vendor>Acme</vendor>
+    <model>Big Horseshoe Magnet</model>
+  </equipment>
+
+  <equipment xsi:type="mi:ElectronMicroscope">
+    <vendor>Micro Heaven</vendor>
+    <model> x1440 </model>
+    <magnification> 1000.0 </magnification>
+  </equipment>
+</ex:Lab>

--- a/unqualified/genericlab.xml
+++ b/unqualified/genericlab.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ex:Lab xmlns:ex="urn:experiments-uq" xmlns=""
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:experiments-uq experiments.xsd">
+  <equipment>
+    <vendor>Acme</vendor>
+    <model>Big Horseshoe Magnet</model>
+  </equipment>
+</ex:Lab>

--- a/unqualified/microscopy.xsd
+++ b/unqualified/microscopy.xsd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="urn:microscopy-uq"
+           xmlns:mi="urn:microscopy-uq"
+           xmlns:ex="urn:experiments-uq"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="unqualified">
+
+  <xs:import namespace="urn:experiments-uq"
+             schemaLocation="file://mdcs/experiments.xsd"/>
+<!--
+  <xs:import namespace="urn:experiments"
+             schemaLocation="experiments.xsd"/>
+  <xs:import namespace="urn:experiments"/>
+  -->
+
+<!--
+  <xs:element name="MicroLab" type="ex:LabSetup"/>
+  -->
+  
+
+  <xs:complexType name="ElectronMicroscope">
+    <xs:complexContent>
+      <xs:extension base="ex:Equipment">
+        <xs:sequence>
+          <xs:element name="magnification" type="xs:decimal"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  
+</xs:schema>


### PR DESCRIPTION
This adds a 2nd instance document to the `extensionSchema` test case which demonstrates the use of `xsi:type`.  It also adds a variation on this test case called `unqualified` which demonstrates the use of `elementDefaultForm="unqualified"`
